### PR TITLE
Update HostUserTeamGZ.sh

### DIFF
--- a/BOINC stats/Overall/Scripts/HostUserTeamGZ.sh
+++ b/BOINC stats/Overall/Scripts/HostUserTeamGZ.sh
@@ -33,20 +33,6 @@ mv team_id team_id.xml
 clamscan
 echo "Einstein end"
 
-echo "ClimatePrediction start"
-cd ../ClimatePrediction
-wget -N --tries=2 http://climateapps2.oucs.ox.ac.uk/cpdnboinc/stats/host.xml.gz
-wget -N --tries=2 http://climateapps2.oucs.ox.ac.uk/cpdnboinc/stats/team.xml.gz
-wget -N --tries=2 http://climateapps2.oucs.ox.ac.uk/cpdnboinc/stats/user.xml.gz
-echo "Downloads finished"
-gunzip host.xml.gz
-clamscan
-gunzip user.xml.gz
-clamscan
-gunzip team.xml.gz
-clamscan
-echo "ClimatePrediction end"
-
 echo "Rosetta start"
 cd ../Rosetta
 wget -N --tries=2 http://boinc.bakerlab.org/rosetta/stats/host.gz
@@ -83,40 +69,43 @@ echo "BURP end"
 
 echo "PrimeGrid start"
 cd ../PrimeGrid
-wget -N --tries=2 http://www.primegrid.com/stats/host_id.gz
-wget -N --tries=2 http://www.primegrid.com/stats/team_id.gz
-wget -N --tries=2 http://www.primegrid.com/stats/user_id.gz
+wget -N --tries=2 http://www.primegrid.com/stats/host.gz
+wget -N --tries=2 http://www.primegrid.com/stats/team.gz
+wget -N --tries=2 http://www.primegrid.com/stats/user.gz
 echo "Downloads finished"
-gunzip host_id.gz
-mv host_id host_id.xml
+gunzip host.gz
+mv host host.xml
 clamscan
-gunzip user_id.gz
-mv user_id user_id.xml
+gunzip user.gz
+mv user user.xml
 clamscan
-gunzip team_id.gz
-mv team_id team_id.xml
+gunzip team.gz
+mv team team.xml
 clamscan
 echo "PrimeGrid end"
 
-echo "Sztaki start"
-cd ../Sztaki
-wget -N --tries=2 http://szdg.lpds.sztaki.hu/szdg/stats/host.xml.gz 
-wget -N --tries=2 http://szdg.lpds.sztaki.hu/szdg/stats/team.xml.gz 
-wget -N --tries=2 http://szdg.lpds.sztaki.hu/szdg/stats/user.xml.gz
+echo "SZTAKI start"
+cd ../SZTAKI
+wget -N --tries=2 http://szdg.lpds.sztaki.hu/szdg/stats/host.gz 
+wget -N --tries=2 http://szdg.lpds.sztaki.hu/szdg/stats/team.gz 
+wget -N --tries=2 http://szdg.lpds.sztaki.hu/szdg/stats/user.gz
 echo "Downloads finished"
-gunzip host.xml.gz
+gunzip host.gz
+mv host host.xml
 clamscan
-gunzip user.xml.gz
+gunzip user.gz
+mv user user.xml
 clamscan
-gunzip team.xml.gz
+gunzip team.gz
+mv team team.xml
 clamscan
-echo "Sztaki end"
+echo "SZTAKI end"
 
 echo "WCG start"
 cd ../WCG
-wget -N --tries=2 http://www.worldcommunitygrid.org/boinc/stats/host.gz
-wget -N --tries=2 http://www.worldcommunitygrid.org/boinc/stats/team.gz
-wget -N --tries=2 http://www.worldcommunitygrid.org/boinc/stats/user.gz
+wget -N --tries=2 https://www.worldcommunitygrid.org/boinc/stats/host.gz
+wget -N --tries=2 https://www.worldcommunitygrid.org/boinc/stats/team.gz
+wget -N --tries=2 https://www.worldcommunitygrid.org/boinc/stats/user.gz
 echo "Downloads finished"
 gunzip host.gz
 mv host host.xml
@@ -128,54 +117,6 @@ gunzip team.gz
 mv team team.xml
 clamscan
 echo "WCG end"
-
-echo "MalariaControl start"
-cd ../MalariaControl
-wget -N --tries=2 http://www.malariacontrol.net/stats/host.gz
-wget -N --tries=2 http://www.malariacontrol.net/stats/team.gz
-wget -N --tries=2 http://www.malariacontrol.net/stats/user.gz
-echo "Downloads finished"
-gunzip host.gz
-mv host host.xml
-clamscan
-gunzip user.gz
-mv user user.xml
-clamscan
-gunzip team.gz
-mv team team.xml
-clamscan
-echo "MalariaControl end"
-
-echo "Lattice start"
-cd ../lattice2
-wget -N --tries=2 http://boinc.umiacs.umd.edu/stats/host.gz
-wget -N --tries=2 http://boinc.umiacs.umd.edu/stats/team.gz
-wget -N --tries=2 http://boinc.umiacs.umd.edu/stats/user.gz
-echo "Downloads finished"
-gunzip host.gz
-mv host host.xml
-clamscan
-gunzip user.gz
-mv user user.xml
-clamscan
-gunzip team.gz
-mv team team.xml
-clamscan
-echo "Lattice end"
-
-echo "BBC-CPDN start"
-cd ../BBC-CPDN
-wget -N --tries=2 http://bbc.cpdn.org/stats/host.xml.gz
-wget -N --tries=2 http://bbc.cpdn.org/stats/team.xml.gz
-wget -N --tries=2 http://bbc.cpdn.org/stats/user.xml.gz
-echo "Downloads finished"
-gunzip host.xml.gz
-clamscan
-gunzip user.xml.gz
-clamscan
-gunzip team.xml.gz
-clamscan
-echo "BBC-CPDN end"
 
 echo "Leiden start"
 cd ../Leiden
@@ -207,23 +148,6 @@ gunzip team.gz
 mv team team.xml
 clamscan
 echo "MooWrap end"
-
-echo "GridcoinFinance start"
-cd ../GridcoinFinance
-wget -N --tries=2 http://finance.gridcoin.us/stats/host.gz
-wget -N --tries=2 http://finance.gridcoin.us/stats/team.gz
-wget -N --tries=2 http://finance.gridcoin.us/stats/user.gz
-echo "Downloads finished"
-gunzip host.gz
-mv host host.xml
-clamscan
-gunzip user.gz
-mv user user.xml
-clamscan
-gunzip team.gz
-mv team team.xml
-clamscan
-echo "GridcoinFinance end"
 
 echo "GPUGRID start"
 cd ../GPUGRID
@@ -276,23 +200,6 @@ mv team team.xml
 clamscan
 echo "Milkyway end"
 
-echo "POEM start"
-cd ../POEM
-wget -N --tries=2 http://boinc.fzk.de/poem/stats/host.gz
-wget -N --tries=2 http://boinc.fzk.de/poem/stats/team.gz
-wget -N --tries=2 http://boinc.fzk.de/poem/stats/user.gz
-echo "Downloads finished"
-gunzip host.gz
-mv host host.xml
-clamscan
-gunzip user.gz
-mv user user.xml
-clamscan
-gunzip team.gz
-mv team team.xml
-clamscan
-echo "POEM end"
-
 echo "Collatz start"
 cd ../Collatz
 wget -N --tries=2 http://boinc.thesonntags.com/collatz/stats/host.gz
@@ -310,28 +217,6 @@ mv team team.xml
 clamscan
 echo "Collatz end"
 
-echo "CSG start"
-cd ../CSG
-wget -N --tries=2 http://csgrid.org/csg/stats/host.gz
-wget -N --tries=2 http://csgrid.org/csg/stats/team.gz
-wget -N --tries=2 http://csgrid.org/csg/stats/user.gz
-wget -N --tries=2 http://csgrid.org/csg/stats/team_work.gz
-wget -N --tries=2 http://csgrid.org/csg/stats/user_work.gz
-echo "Downloads finished"
-gunzip host.gz
-mv host host.xml
-clamscan
-gunzip user.gz
-mv user user.xml
-clamscan
-gunzip user_work.gz
-mv user_work user_work.xml
-clamscan
-gunzip team_work.gz
-mv team_work team_work.xml
-clamscan
-echo "CSG end"
-
 echo "YAFU start"
 cd ../YAFU
 wget -N --tries=2 http://yafu.myfirewall.org/yafu/stats/host.gz
@@ -348,23 +233,6 @@ gunzip team.gz
 mv team team.xml
 clamscan
 echo "YAFU end"
-
-echo "FindAtHome start"
-cd ../FindAtHome
-wget -N --tries=2 http://findah.ucd.ie/stats/host.gz
-wget -N --tries=2 http://findah.ucd.ie/stats/team.gz
-wget -N --tries=2 http://findah.ucd.ie/stats/user.gz
-echo "Downloads finished"
-gunzip host.gz
-mv host host.xml
-clamscan
-gunzip user.gz
-mv user user.xml
-clamscan
-gunzip team.gz
-mv team team.xml
-clamscan
-echo "FindAtHome end"
 
 echo "Cosmology start"
 cd ../Cosmology
@@ -399,23 +267,6 @@ gunzip team.gz
 mv team team.xml
 clamscan
 echo "vLHC end"
-
-echo "MindModeling start"
-cd ../MindModeling
-wget -N --tries=2 https://mindmodeling.org/stats/host.gz
-wget -N --tries=2 https://mindmodeling.org/stats/team.gz
-wget -N --tries=2 https://mindmodeling.org/stats/user.gz
-echo "Downloads finished"
-gunzip host.gz
-mv host host.xml
-clamscan
-gunzip user.gz
-mv user user.xml
-clamscan
-gunzip team.gz
-mv team team.xml
-clamscan
-echo "MindModeling end"
 
 echo "NFS start"
 cd ../NFS
@@ -492,23 +343,6 @@ gunzip team.gz
 mv team team.xml
 clamscan
 echo "YOYO end"
-
-echo "SAT start"
-cd ../SAT
-wget -N --tries=2 http://sat.isa.ru/pdsat/stats/host.gz
-wget -N --tries=2 http://sat.isa.ru/pdsat/stats/team.gz
-wget -N --tries=2 http://sat.isa.ru/pdsat/stats/user.gz
-echo "Downloads finished"
-gunzip host.gz
-mv host host.xml
-clamscan
-gunzip user.gz
-mv user user.xml
-clamscan
-gunzip team.gz
-mv team team.xml
-clamscan
-echo "SAT end"
 
 echo "ATLAS start"
 cd ../ATLAS


### PR DESCRIPTION
removed: csg, lattice, malaria control, bbc-cpdn, cpdn, gridcoin finance, poem, sat, mindmodelling, and find@home.
https wcg.
fixed sztaki and primegrid download links... and hopefully fixed the extraction part correctly.
capitalized SZTAKI.

need to add: ddm, drugdiscovery, enigma, lhc, srbase, tn-grid, universe, and vgtu.